### PR TITLE
New graph import write case

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ BIN_FILE=bin/${GOOS}/${GOARCH}/collectionmaker
 
 # Build binary locally.
 build:
-	go build -o ${BIN_FILE}
+	go build -o ${BIN_FILE} -tags netgo
 
 # Build binary without installed GO and copy it to the local system.
 docker:

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -18,4 +18,5 @@ func init() {
 	cmdCreate.AddCommand(cmdCreateCollection)
 	cmdCreate.AddCommand(cmdCreateGraph)
 	cmdCreate.AddCommand(cmdCreateEdgeCol)
+	cmdCreate.AddCommand(cmdCreateGraphCols)
 }

--- a/cmd/create_graph.go
+++ b/cmd/create_graph.go
@@ -35,6 +35,7 @@ type Instance struct {
 }
 
 type Step struct {
+  Key      string `json:"_key,omitempty"`
 	TenantId string `json:"tenantId"`
 	From     string `json:"_from"`
 	To       string `json:"_to"`

--- a/cmd/create_graphscols.go
+++ b/cmd/create_graphscols.go
@@ -1,0 +1,112 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"github.com/arangodb/go-driver"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+var (
+	cmdCreateGraphCols = &cobra.Command{
+		Use:   "graphcols",
+		Short: "Create collections for a graph",
+		RunE:  createGraphCols,
+	}
+)
+
+func init() {
+	var drop = false
+	var replicationFactor int
+	var numberOfShards int
+
+	cmdCreateGraphCols.Flags().BoolVar(&drop, "drop", drop, "set -drop to true to drop data before start")
+	cmdCreateGraphCols.Flags().IntVar(&replicationFactor, "replicationFactor", 3, "replication factor for edge collection")
+	cmdCreateGraphCols.Flags().IntVar(&numberOfShards, "numberOfShards", 42, "number of shards of edge collection")
+}
+
+func createGraphCols(cmd *cobra.Command, _ []string) error {
+	drop, _ := cmd.Flags().GetBool("drop")
+	db, err := _client.Database(context.Background(), "_system")
+	if err != nil {
+		return errors.Wrapf(err, "can not get database: %s", "_system")
+	}
+
+	if err := setupGraphVertexCol(cmd, drop, db); err != nil {
+		return errors.Wrapf(err, "can not create graph vertex collection")
+	}
+	if err := setupGraphEdgeCol(cmd, drop, db); err != nil {
+		return errors.Wrapf(err, "can not create graph edge collection")
+	}
+
+	return nil
+}
+
+// setupGraphVertexCol will set up a single vertex collecion
+func setupGraphVertexCol(cmd *cobra.Command, drop bool, db driver.Database) error {
+	replicationFactor, _ := cmd.Flags().GetInt("replicationFactor")
+	numberOfShards, _ := cmd.Flags().GetInt("numberOfShards")
+
+	ec, err := db.Collection(nil, "instances")
+	if err == nil {
+		if !drop {
+			fmt.Printf("Found vertex collection 'instances' already, setup is already done.\n")
+			return nil
+		}
+		err = ec.Remove(nil)
+		if err != nil {
+			fmt.Printf("Could not drop vertex collection 'instances': %v\n", err)
+			return err
+		}
+	} else if !driver.IsNotFound(err) {
+		fmt.Printf("Error: could not look for vertex collection 'instances': %v\n", err)
+		return err
+	}
+
+	// Now create the vertex collection:
+	_, err = db.CreateCollection(nil, "instances", &driver.CreateCollectionOptions{
+			Type: driver.CollectionTypeDocument,
+			NumberOfShards: numberOfShards,
+			ReplicationFactor: replicationFactor,
+	})
+	if err != nil {
+		fmt.Printf("Error: could not create vertex collection 'instances': %v\n", err)
+		return err
+	}
+	return nil
+}
+
+// setupGraphEdgeCol will set up a single edge collecion
+func setupGraphEdgeCol(cmd *cobra.Command, drop bool, db driver.Database) error {
+	replicationFactor, _ := cmd.Flags().GetInt("replicationFactor")
+	numberOfShards, _ := cmd.Flags().GetInt("numberOfShards")
+
+	ec, err := db.Collection(nil, "steps")
+	if err == nil {
+		if !drop {
+			fmt.Printf("Found edge collection 'steps' already, setup is already done.\n")
+			return nil
+		}
+		err = ec.Remove(nil)
+		if err != nil {
+			fmt.Printf("Could not drop edge collection 'steps': %v\n", err)
+			return err
+		}
+	} else if !driver.IsNotFound(err) {
+		fmt.Printf("Error: could not look for edge collection 'steps': %v\n", err)
+		return err
+	}
+
+	// Now create the edge collection:
+	_, err = db.CreateCollection(nil, "steps", &driver.CreateCollectionOptions{
+			Type: driver.CollectionTypeEdge,
+			NumberOfShards: numberOfShards,
+			ReplicationFactor: replicationFactor,
+	})
+	if err != nil {
+		fmt.Printf("Error: could not create edge collection 'steps': %v\n", err)
+		return err
+	}
+	return nil
+}

--- a/cmd/write.go
+++ b/cmd/write.go
@@ -16,4 +16,5 @@ func init() {
 	cmdRoot.AddCommand(cmdWrite)
 	cmdWrite.AddCommand(cmdWriteEdges)
 	cmdWrite.AddCommand(cmdElCheapoWrites)
+	cmdWrite.AddCommand(cmdWriteGraph)
 }

--- a/cmd/write_edges.go
+++ b/cmd/write_edges.go
@@ -132,7 +132,6 @@ func writeSomeEdges(nrEdges int64, id string, db driver.Database, mutex *sync.Mu
 			mutex.Lock()
 			fmt.Printf("%s Have imported %d paths for id %s.\n", time.Now(), i * 1000, id)
 			mutex.Unlock()
-			cancel()
 		}
     times = append(times, time.Now().Sub(start))
 		if len(times) % 100 == 0 {

--- a/cmd/write_graph.go
+++ b/cmd/write_graph.go
@@ -1,0 +1,205 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"github.com/arangodb/go-driver"
+  "github.com/neunhoef/collectionmaker/pkg/database"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"math/rand"
+	"sort"
+	"strconv"
+	"sync"
+	"time"
+)
+
+var (
+	cmdWriteGraph = &cobra.Command{
+		Use:   "graph",
+		Short: "Write vertices and edges and update them",
+		RunE:  writeGraph,
+	}
+)
+
+// This uses the types Instance and Step from "create_graph.go"
+
+func init() {
+	var parallelism int = 1
+	var startDelay int64 = 5
+	var number int64 = 1000000
+	cmdWriteGraph.Flags().IntVar(&parallelism, "parallelism", parallelism, "set -parallelism to use multiple go routines")
+	cmdWriteGraph.Flags().Int64Var(&number, "number", number, "set -number for number of edges to write per go routine")
+	cmdWriteGraph.Flags().Int64Var(&startDelay, "start-delay", startDelay, "Delay between the start of two go routines.")
+}
+
+// writeGraph writes edges in parallel
+func writeGraph(cmd *cobra.Command, _ []string) error {
+	parallelism, _ := cmd.Flags().GetInt("parallelism")
+	number, _ := cmd.Flags().GetInt64("number")
+	startDelay, _ := cmd.Flags().GetInt64("start-delay")
+
+	db, err := _client.Database(context.Background(), "_system")
+	if err != nil {
+		return errors.Wrapf(err, "can not get database: %s", "_system")
+	}
+
+	if err := writeGraphParallel(parallelism, number, startDelay, db); err != nil {
+		return errors.Wrapf(err, "can not setup some tenants")
+	}
+
+	return nil
+}
+
+// writeSomeGraphParallel creates some edges in parallel
+func writeGraphParallel(parallelism int, number int64, startDelay int64, db driver.Database) error {
+	var mutex sync.Mutex
+	totaltimestart := time.Now()
+	wg := sync.WaitGroup{}
+	haveError := false
+	for i := 1; i <= parallelism; i++ {
+	  time.Sleep(time.Duration(startDelay) * time.Millisecond)
+		i := i // bring into scope
+		wg.Add(1)
+
+		go func(wg *sync.WaitGroup, i int) {
+			defer wg.Done()
+			fmt.Printf("Starting go routine...\n")
+			id := "id_" + strconv.FormatInt(int64(i), 10)
+			err := writeSomeGraph(number, id, db, &mutex)
+			if err != nil {
+				fmt.Printf("writeSomeGraph error: %v\n", err)
+				haveError = true
+			}
+			mutex.Lock()
+			fmt.Printf("Go routine %d done\n", i)
+			mutex.Unlock()
+		}(&wg, i)
+	}
+
+	wg.Wait()
+	totaltimeend := time.Now()
+	totaltime := totaltimeend.Sub(totaltimestart)
+	docspersec := float64(int64(parallelism) * number) / (float64(totaltime) / float64(time.Second))
+	fmt.Printf("\nTotal number of edges written: %d, total time: %v, total edges per second: %f\n", int64(parallelism) * number, totaltimeend.Sub(totaltimestart), docspersec)
+	if !haveError {
+		return nil
+	}
+	fmt.Printf("Error in writeSomeGraph.\n")
+	return fmt.Errorf("Error in writeSomeGraph.")
+}
+
+// writeOneTenant does `nr` write operations, alternating between vertices
+// and edges and inserts and updates.
+func writeSomeGraph(nr int64, id string, db driver.Database, mutex *sync.Mutex) error {
+	instances, err := db.Collection(nil, "instances")
+	if err != nil {
+		fmt.Printf("writeSomeGraph: could not open `instances` collection: %v\n", err)
+		return err
+	}
+	steps, err := db.Collection(nil, "steps")
+	if err != nil {
+		fmt.Printf("writeSomeGraph: could not open `steps` collection: %v\n", err)
+		return err
+	}
+	optype := 0   // changes from 0 to 3 and then back to 0
+  times := make([]time.Duration, 0, 10000)
+	cyclestart := time.Now()
+	for i := int64(0); i < nr; i++ {
+		start := time.Now()
+		switch (optype) {
+		case 0:  // write a new vertex
+		  inst := Instance{
+				Key: "I" + id + "_" + strconv.FormatInt(i/4, 10),
+			  TenantId: "T" + strconv.FormatInt(int64(rand.Intn(10000)), 10),
+				Payload: database.MakeRandomString(1400),
+		  }
+			ctx, cancel := context.WithTimeout(context.Background(), time.Hour)
+			_, err := instances.CreateDocument(ctx, &inst)
+			cancel()
+			if err != nil {
+				fmt.Printf("writeSomeGraph: could not write vertex: %v\n", err)
+				return err
+			}
+		case 1:  // write a new edge
+		  step := Step{
+				Key: "S" + id + "_" + strconv.FormatInt(i/4, 10),
+				From: "instances/I" + id + "_" + strconv.FormatInt(i/4, 10),
+				To:   "instances/I" + id + "_" + strconv.FormatInt(i/4, 10),
+			  TenantId: "T" + strconv.FormatInt(int64(rand.Intn(10000)), 10),
+				Payload: database.MakeRandomString(700),
+		  }
+			ctx, cancel := context.WithTimeout(context.Background(), time.Hour)
+			_, err := steps.CreateDocument(ctx, &step)
+			cancel()
+			if err != nil {
+				fmt.Printf("writeSomeGraph: could not write edge: %v\n", err)
+				return err
+			}
+		case 2:  // modify an existing vertex
+		  var previous int64
+		  if i < 4 {
+				previous = 0
+			} else {
+				previous = rand.Int63n(i/4)
+			}
+			key := "I" + id + "_" + strconv.FormatInt(previous/4, 10)
+		  inst := Instance{
+				Key: key,
+			  TenantId: "T" + strconv.FormatInt(int64(rand.Intn(10000)), 10),
+				Payload: database.MakeRandomString(1400),
+		  }
+			ctx, cancel := context.WithTimeout(context.Background(), time.Hour)
+			_, err := instances.ReplaceDocument(ctx, key, &inst)
+			cancel()
+			if err != nil {
+				fmt.Printf("writeSomeGraph: could not replace vertex: %v\n", err)
+				return err
+			}
+		case 3:  // modify an existing edge
+		  var previous int64
+		  if i < 4 {
+				previous = 0
+			} else {
+				previous = rand.Int63n(i/4)
+			}
+			key := "S" + id + "_" + strconv.FormatInt(previous/4, 10)
+		  step := Step{
+				Key: key,
+				From: "instances/I" + id + "_" + strconv.FormatInt(i/4, 10),
+				To:   "instances/I" + id + "_" + strconv.FormatInt(i/4, 10),
+			  TenantId: "T" + strconv.FormatInt(int64(rand.Intn(10000)), 10),
+				Payload: database.MakeRandomString(700),
+		  }
+			ctx, cancel := context.WithTimeout(context.Background(), time.Hour)
+			_, err := steps.ReplaceDocument(ctx, key, &step)
+			cancel()
+			if err != nil {
+				fmt.Printf("writeSomeGraph: could not replace edge: %v\n", err)
+				return err
+			}
+	  }
+
+    times = append(times, time.Now().Sub(start))
+		if ((i+1) % 10000 == 0 || i == nr - 1) && len(times) != 0 {
+			mutex.Lock()
+			fmt.Printf("%s Have imported %d paths for id %s.\n", time.Now(), i+1, id)
+			mutex.Unlock()
+			sort.Sort(DurationSlice(times))
+			number := int64(len(times))
+			var sum int64 = 0
+			for _, t := range times {
+				sum = sum + int64(t)
+			}
+			totaltime := time.Now().Sub(cyclestart)
+			docspersec := float64(number) / (float64(totaltime) / float64(time.Second))
+			mutex.Lock()
+			fmt.Printf("Times for last %d writes: %s (median), %s (90%%ile), %s (99%%ilie), %s (average), edges per second in this go routine: %f\n", number, times[number / 2], times[number * 9 / 10], times[number * 99 / 100], time.Duration(sum/number), docspersec)
+			mutex.Unlock()
+			times = times[0:0]
+			cyclestart = time.Now()
+		}
+		optype = (optype + 1) & 3
+	}
+	return nil
+}

--- a/cmd/write_graph.go
+++ b/cmd/write_graph.go
@@ -56,13 +56,11 @@ func writeGraphParallel(parallelism int, number int64, startDelay int64, db driv
 	var mutex sync.Mutex
 	totaltimestart := time.Now()
 	wg := sync.WaitGroup{}
+	wg.Add(parallelism)
 	haveError := false
 	for i := 1; i <= parallelism; i++ {
 	  time.Sleep(time.Duration(startDelay) * time.Millisecond)
-		i := i // bring into scope
-		wg.Add(1)
-
-		go func(wg *sync.WaitGroup, i int) {
+		go func(i int) {
 			defer wg.Done()
 			fmt.Printf("Starting go routine...\n")
 			id := "id_" + strconv.FormatInt(int64(i), 10)
@@ -74,7 +72,7 @@ func writeGraphParallel(parallelism int, number int64, startDelay int64, db driv
 			mutex.Lock()
 			fmt.Printf("Go routine %d done\n", i)
 			mutex.Unlock()
-		}(&wg, i)
+		}(i)
 	}
 
 	wg.Wait()


### PR DESCRIPTION
This adds a new writing use case:

Single operations with larger vertices and edges (approx. 1500 resp. 750 bytes)
No batches.
No transactions.
Mixture of inserts and updates (so far 50%/50%).
